### PR TITLE
Create baas instance

### DIFF
--- a/controllers/instanceController.js
+++ b/controllers/instanceController.js
@@ -30,6 +30,10 @@ const createBaaS = (req, res, next) => {
         ParameterValue: process.env.SGAppServer
       },
       {
+        ParameterKey: 'ALBListener',
+        ParameterValue: process.env.ALBListener
+      },
+      {
         ParameterKey: 'SGDBServer',
         ParameterValue: process.env.SGDBServer
       }

--- a/controllers/instanceController.js
+++ b/controllers/instanceController.js
@@ -12,6 +12,26 @@ const createBaaS = (req, res, next) => {
       {
         ParameterKey: 'VPCID',
         ParameterValue: process.env.VpcId
+      },
+      {
+        ParameterKey: 'AppTierSubnet',
+        ParameterValue: process.env.AppTierSubnet
+      },
+      {
+        ParameterKey: 'DBTierSubnet',
+        ParameterValue: process.env.DBTierSubnet
+      },
+      {
+        ParameterKey: 'EFSSecurityGroup',
+        ParameterValue: process.env.EFSSecurityGroup
+      },
+      {
+        ParameterKey: 'SGAppServer',
+        ParameterValue: process.env.SGAppServer
+      },
+      {
+        ParameterKey: 'SGDBServer',
+        ParameterValue: process.env.SGDBServer
       }
     ],
     Capabilities: ['CAPABILITY_NAMED_IAM']
@@ -25,15 +45,6 @@ const createBaaS = (req, res, next) => {
     return res.status(200).json(data);
   });
 };
-
-const testfs = (req, res, next) => {
-  try {
-    const template = fs.readFileSync(path.resolve(__dirname, '../utils/bastion-instance-no-comments.yaml'), 'utf8');
-    res.send(template);
-  } catch (err) {
-    res.send(err);
-  }
-}
 
 const destroyBaaS = (req, res, next) => {
   const body = req.body;
@@ -75,4 +86,3 @@ exports.createBaaS = createBaaS;
 exports.destroyBaaS = destroyBaaS;
 exports.getBaaSInstances = getBaaSInstances;
 exports.getBaaSInstance = getBaaSInstance;
-exports.testfs = testfs;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ const env = (req, res, next) => {
     AppServerIAMRole: process.env.AppServerIAMRole,
     DBServerIAMRole: process.env.DBServerIAMRole,
     AppServerIAMRoleArn: process.env.AppServerIAMRoleArn,
-    DBServerIAMRoleArn: process.env.DBServerIAMRoleArn
+    DBServerIAMRoleArn: process.env.DBServerIAMRoleArn,
+    ALBListener: process.env.ALBListener
   };
   res.json(envVars);
 }
@@ -42,10 +43,13 @@ const app = express();
 app.use(express.json());
 
 app.get('/', test);
+app.get('/admin/', test);
 app.get('/env', env);
+app.get('/admin/env', env);
 app.get('/db', db);
+app.get('/admin/db', db);
 
-app.use('/instances', instanceRoutes);
-app.use('/db', dbRoutes);
+app.use('/admin/instances', instanceRoutes);
+app.use('/admin/db', dbRoutes);
 
 app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ const env = (req, res, next) => {
   res.json(envVars);
 }
 
+const Cat = mongoose.model('Cat', { name: String });
+
 const db = (req, res, next) => {
   mongoose.connect('mongodb://localhost:27017')
     .then(result => {
@@ -39,6 +41,32 @@ const db = (req, res, next) => {
     });
 }
 
+const addCat = (req, res, next) => {
+  const kitty = new Cat({ name: 'Pavlo' });
+  console.log('in test route');
+  kitty.save()
+    .then(response => {
+      console.log(response);
+      res.send(response);
+    })
+    .catch(error => {
+      console.log(error);
+      res.send(error);
+    });
+}
+
+const findCats = (req, res, next) => {
+  Cat.find({})
+    .then(response => {
+      console.log(response);
+      res.json(response);
+    })
+    .catch(error => {
+      console.log(error);
+      res.status(418).send();
+    });
+}
+
 const app = express();
 app.use(express.json());
 
@@ -48,6 +76,8 @@ app.get('/env', env);
 app.get('/admin/env', env);
 app.get('/db', db);
 app.get('/admin/db', db);
+app.get('/admin/addCat', addCat);
+app.get('/admin/findCats', findCats);
 
 app.use('/admin/instances', instanceRoutes);
 app.use('/admin/db', dbRoutes);

--- a/routes/instanceRouter.js
+++ b/routes/instanceRouter.js
@@ -7,6 +7,4 @@ instanceRouter.delete('/destroyBaaS/:id', instanceController.destroyBaaS);
 instanceRouter.get('/getBaaSInstances', instanceController.getBaaSInstances);
 instanceRouter.get('/getBaaSInstance/:id', instanceController.getBaaSInstance);
 
-instanceRouter.get('/testfs', instanceController.testfs);
-
 module.exports = instanceRouter;

--- a/utils/bastion-instance-no-comments.yaml
+++ b/utils/bastion-instance-no-comments.yaml
@@ -3,9 +3,18 @@ Parameters:
   VPCID:
     Type: String
     Default: vpc-0506ed18846c90ba5
-  SubnetID:
+  AppTierSubnet:
     Type: String
     Default: subnet-00369caabdf4fa5a6
+  DBTierSubnet:
+    Type: String
+    Default: subnet-00369caabdf4fa5a6
+  EFSSecurityGroup:
+    Type: String
+  SGAppServer:
+    Type: String
+  SGDBServer:
+    Type: String
   NewNameSpace:
     Type: String
     Default: bastion
@@ -36,7 +45,7 @@ Resources:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
           Subnets:
-            -  !Ref SubnetID
+            -  !Ref AppTierSubnet 
           SecurityGroups:
             - !Ref AppServerSecurityGroup
     DependsOn:
@@ -131,7 +140,7 @@ Resources:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
           Subnets:
-            - !Ref SubnetID
+            - !Ref AppTierSubnet 
           SecurityGroups:
             - !Ref DatabaseSecurityGroup
     DependsOn:
@@ -157,7 +166,7 @@ Resources:
       ContainerDefinitions:
         - Name: mongo
           Essential: true
-          Image: 'mongo:latest'
+          Image: 'public.ecr.aws/y7d9d7k6/mongo:5.0.6'
           PortMappings:
             - ContainerPort: 27017
               HostPort: 27017
@@ -220,7 +229,7 @@ Resources:
     Properties:
       Description: Service Discovery Namespace for BaaS Instance
       Vpc: !Ref VPCID
-      Name: bastion
+      Name: !Ref NewNameSpace 
   AppServerServiceDiscoveryEntry:
     Type: 'AWS::ServiceDiscovery::Service'
     Properties:
@@ -257,7 +266,7 @@ Resources:
     Properties:
       Encrypted: true
       PerformanceMode: generalPurpose
-  EFSSecurityGroup:
+  EFSSecurityGroupREMOVE:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       SecurityGroupIngress:
@@ -278,7 +287,6 @@ Resources:
       FileSystemId: !Ref InstanceEFS
       SecurityGroups:
         - !Ref EFSSecurityGroup
-      SubnetId: !Ref SubnetID
+      SubnetId: !Ref AppTierSubnet 
     DependsOn:
       - InstanceEFS
-      - EFSSecurityGroup

--- a/utils/bastion-instance-no-comments.yaml
+++ b/utils/bastion-instance-no-comments.yaml
@@ -15,9 +15,14 @@ Parameters:
     Type: String
   SGDBServer:
     Type: String
+  ALBListener:
+    Type: String
   NewNameSpace:
     Type: String
     Default: bastion
+  ListenerRulePriority:
+    Type: Number 
+    Default: 2
 Resources:
   BaaSECSCluster:
     Type: 'AWS::ECS::Cluster'
@@ -48,12 +53,18 @@ Resources:
             -  !Ref AppTierSubnet 
           SecurityGroups:
             - !Ref AppServerSecurityGroup
+      LoadBalancers:
+        - ContainerPort: 3001
+          ContainerName: app-server 
+          TargetGroupArn:
+            Ref: AppServerTargetGroup
     DependsOn:
       - AppServerTask
       - AppServerServiceDiscoveryEntry
       - BaaSECSCluster
       - AppServerSecurityGroup
       - DatabaseECSService
+      - AppServerTargetGroup
   AppServerTask:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
@@ -72,7 +83,7 @@ Resources:
       ContainerDefinitions:
         - Name: app-server
           Essential: 'true'
-          Image: 'public.ecr.aws/y7d9d7k6/app-server:0.4.0'
+          Image: 'public.ecr.aws/y7d9d7k6/app-server:0.5.0'
           PortMappings:
             - ContainerPort: 3001
               HostPort: 3001
@@ -290,3 +301,29 @@ Resources:
       SubnetId: !Ref AppTierSubnet 
     DependsOn:
       - InstanceEFS
+  AppServerTargetGroup:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      VpcId: !Ref VPCID
+      Name: AppServerTargetGroup
+      HealthCheckEnabled: true
+      Port: 3001
+      Protocol: HTTP
+      TargetType: ip
+  AppServerALBListenerRule:
+    Type: 'AWS::ElasticLoadBalancingV2::ListenerRule'
+    Properties:
+      ListenerArn: !Ref ALBListener
+      Priority: !Ref ListenerRulePriority
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - /server/*
+      Actions:
+        - Type: forward
+          ForwardConfig:
+            TargetGroups:
+              - TargetGroupArn: !Ref AppServerTargetGroup
+                Weight: 1
+    


### PR DESCRIPTION
Added route-based load balancing. All routes with `/server/*` are routed to the app server. Still need to add `/server/:id/*` so that multiple instances can be supported. Also added test routes for testing EFS integration with the mongo container.