### PR TITLE
Use name parameter on collections routes

### DIFF
--- a/controllers/collectionController.js
+++ b/controllers/collectionController.js
@@ -13,9 +13,9 @@ const getCollections = (req, res, next) => {
 
 const getCollection = (req, res, next) => {
   const stackName = req.params.stackName;
-  const id = req.params.id;
+  const name = req.params.name;
 
-  const url = createURL(stackName, `/collections/${id}`);
+  const url = createURL(stackName, `/collections/${name}`);
   axios.get(url, req.axiosConfig)
     .then(response => res.json(response.data))
     .catch(err => next(new HttpError(err, 500)));
@@ -32,9 +32,9 @@ const createCollection = (req, res, next) => {
 
 const deleteCollection = (req, res, next) => {
   const stackName = req.params.stackName;
-  const id = req.params.id;
+  const name = req.params.name;
 
-  const url = createURL(stackName, `/collections/${id}`);
+  const url = createURL(stackName, `/collections/${name}`);
   axios.delete(url, req.axiosConfig)
     .then(response => res.status(204).json(response.data))
     .catch(err => next(new HttpError(err, 500)));

--- a/routes/collectionRouter.js
+++ b/routes/collectionRouter.js
@@ -3,9 +3,9 @@ const collectionRouter = express.Router();
 const collectionController = require('../controllers/collectionController');
 const { addApiKey } = require('../utils/middleware');
 
-collectionRouter.delete('/:stackName/:id', addApiKey, collectionController.deleteCollection);
+collectionRouter.delete('/:stackName/:name', addApiKey, collectionController.deleteCollection);
 collectionRouter.get('/:stackName/', addApiKey, collectionController.getCollections);
-collectionRouter.get('/:stackName/:id', addApiKey, collectionController.getCollection);
+collectionRouter.get('/:stackName/:name', addApiKey, collectionController.getCollection);
 collectionRouter.post('/:stackName', addApiKey, collectionController.createCollection);
 
 module.exports = collectionRouter;


### PR DESCRIPTION
We don't have a `collections` collection in the `admin-app` that we save the additional collections.

So currently, there is no way of retrieving them via `id` as it doesn't exist. We could add this feature if you want, but for below changes are needed to make our stack work.