### PR TITLE
Coordinate CLI CF with Admin-App CF

### DIFF
--- a/controllers/instanceController.js
+++ b/controllers/instanceController.js
@@ -8,7 +8,7 @@ const cloudformation = new aws.CloudFormation();
 const Instance = require('../models/instance');
 const HttpError = require('../models/httpError');
 const { createParams, isValidStackName } = require('../utils/helper');
-const TemplateBody = fs.readFileSync(path.resolve(__dirname, '../utils/bastion-development.yaml'), 'utf8');
+const TemplateBody = fs.readFileSync(path.resolve(__dirname, '../utils/bastion-production.yaml'), 'utf8');
 
 const createBaaS = (req, res, next) => {
   const stackName = req.body?.name;

--- a/db/index.js
+++ b/db/index.js
@@ -24,8 +24,7 @@ const setRulePriority = async () => {
       console.log(`Rule priority is checked. It was: ${rulePriority}`);
       result = 'connected';
     } else {
-      // if no rule priority exists, make one with value of 2
-      await RulePriority.create({ Current: 2 })
+      await RulePriority.create({ Current: 1 })
       console.log('Rule priority is set');
       result = 'connected';
     }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
       - DBTierSubnet=development
       - AppTierSubnet=development
       - EFSSecurityGroup=development
+      - SGAppServer=development
       - SGDBServer=development
       - AppServerIAMRole=development
       - DBServerIAMRole=development

--- a/index.js
+++ b/index.js
@@ -42,9 +42,9 @@ app.use('/admin/files', fileRoutes);
 app.get('/*', function(req, res) {
   res.sendFile(path.join(__dirname, './build/index.html'), function(err) {
     if (err) {
-      res.status(500).send(err)
+      res.status(500).send(err);
     }
-  })
+  });
 });
 
 app.use(errorMiddleware);

--- a/utils/bastion-development.yaml
+++ b/utils/bastion-development.yaml
@@ -23,7 +23,7 @@ Parameters:
     Type: String
   ListenerRulePriority:
     Type: Number 
-    Default: 2
+    Default: 1
   TargetGroupName:
     Type: String 
     Default: AppServerTargetGroup
@@ -40,6 +40,10 @@ Parameters:
     Default: 'xxxxxxxxxxxxxxxxxxxxx'
   DBHost:
     Type: String
+  AppTaskFamily:
+    Type: String
+  DBTaskFamily:
+    Type: String
 Resources:
   BaaSECSCluster:
     Type: 'AWS::ECS::Cluster'
@@ -47,6 +51,12 @@ Resources:
       CapacityProviders:
         - FARGATE
       ClusterName: !Ref ClusterName
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+      Tags:
+        - Key: stack
+          Value: Bastion
   AppServerECSService:
     Type: 'AWS::ECS::Service'
     Properties:
@@ -83,6 +93,7 @@ Resources:
   AppServerTask:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
+      Family: !Ref AppTaskFamily
       NetworkMode: awsvpc
       ExecutionRoleArn: !GetAtt 
         - AppServerTaskRole
@@ -185,6 +196,7 @@ Resources:
   DatabaseTask:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
+      Family: !Ref DBTaskFamily
       NetworkMode: awsvpc
       ExecutionRoleArn: !GetAtt 
         - DatabaseTaskRole

--- a/utils/bastion-production.yaml
+++ b/utils/bastion-production.yaml
@@ -1,15 +1,12 @@
-# Production copy. Remove SGs, Roles and Log Groups before updating
+# Production copy.
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
   VPCID:
     Type: String
-    Default: vpc-0506ed18846c90ba5
   AppTierSubnet:
     Type: String
-    Default: subnet-00369caabdf4fa5a6
   DBTierSubnet:
     Type: String
-    Default: subnet-00369caabdf4fa5a6
   EFSSecurityGroup:
     Type: String
   SGAppServer:
@@ -18,24 +15,50 @@ Parameters:
     Type: String
   ALBListener:
     Type: String
-  NewNameSpace:
+  StackName:
     Type: String
-    Default: bastion
+  StackBucketName:
+    Type: String
   ListenerRulePriority:
     Type: Number
-    Default: 2
-  AppId:
+    Default: 1
+  TargetGroupName:
+    Type: String
+    Default: AppServerTargetGroup
+  AppServerLG:
+    Type: String
+  ClusterName:
+    Type: String
+    Default: BaaSECSCluster
+  RoutingPath:
+    Type: String
+    Default: /server/*
+  ApiKey:
     Type: String
     Default: 'xxxxxxxxxxxxxxxxxxxxx'
+  DBHost:
+    Type: String
+  RoleAppServer:
+    Type: String
+  RoleDBServer:
+    Type: String
+  AppTaskFamily:
+    Type: String
+  DBTaskFamily:
+    Type: String
 Resources:
   BaaSECSCluster:
     Type: 'AWS::ECS::Cluster'
     Properties:
       CapacityProviders:
         - FARGATE
-      ClusterName: BaaSECSCluster
-    DependsOn:
-      - AppServerLG
+      ClusterName: !Ref ClusterName
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+      Tags:
+        - Key: stack
+          Value: Bastion
   AppServerECSService:
     Type: 'AWS::ECS::Service'
     Properties:
@@ -52,11 +75,11 @@ Resources:
             - Arn
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
+          AssignPublicIp: DISABLED
           Subnets:
             -  !Ref AppTierSubnet
           SecurityGroups:
-            - !Ref AppServerSecurityGroup
+            - !Ref SGAppServer
       LoadBalancers:
         - ContainerPort: 3001
           ContainerName: app-server
@@ -66,19 +89,15 @@ Resources:
       - AppServerTask
       - AppServerServiceDiscoveryEntry
       - BaaSECSCluster
-      - AppServerSecurityGroup
       - DatabaseECSService
       - AppServerTargetGroup
   AppServerTask:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
+      Family: !Ref AppTaskFamily
       NetworkMode: awsvpc
-      ExecutionRoleArn: !GetAtt 
-        - AppServerTaskRole
-        - Arn
-      TaskRoleArn: !GetAtt 
-        - AppServerTaskRole
-        - Arn
+      ExecutionRoleArn: !Ref RoleAppServer
+      TaskRoleArn: !Ref RoleAppServer
       RequiresCompatibilities:
         - FARGATE
       Family: fargate-task-definition
@@ -87,7 +106,7 @@ Resources:
       ContainerDefinitions:
         - Name: app-server
           Essential: 'true'
-          Image: 'public.ecr.aws/y7d9d7k6/app-server:0.5.0'
+          Image: 'public.ecr.aws/k2f8i0u8/app-server:0.9.11'
           PortMappings:
             - ContainerPort: 3001
               HostPort: 3001
@@ -96,14 +115,18 @@ Resources:
             Options:
               awslogs-group: !Ref AppServerLG
               awslogs-region: !Ref 'AWS::Region'
-              awslogs-stream-prefix: ecs
+              awslogs-stream-prefix: !Ref StackName
           Environment:
-            - Name: appId
-              Value: !Ref AppId
+            - Name: apiKey
+              Value: !Ref ApiKey
+            - Name: stackName
+              Value: !Ref StackName
+            - Name: DB_HOST
+              Value: !Ref DBHost
+            - Name: stackBucketName
+              Value: !Ref StackBucketName
     DependsOn:
       - BaaSECSCluster
-      - AppServerLG
-      - AppServerTaskRole
   DatabaseECSService:
     Type: 'AWS::ECS::Service'
     Properties:
@@ -120,33 +143,29 @@ Resources:
             - Arn
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
+          AssignPublicIp: DISABLED
           Subnets:
             - !Ref AppTierSubnet
           SecurityGroups:
-            - !Ref DatabaseSecurityGroup
+            - !Ref SGDBServer
     DependsOn:
       - DatabaseServiceDiscoveryEntry
       - DatabaseTask
       - BaaSECSCluster
-      - DatabaseSecurityGroup
   DatabaseTask:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
+      Family: !Ref DBTaskFamily
       NetworkMode: awsvpc
-      ExecutionRoleArn: !GetAtt 
-        - DatabaseTaskRole
-        - Arn
-      TaskRoleArn: !GetAtt 
-        - DatabaseTaskRole
-        - Arn
+      ExecutionRoleArn: !Ref RoleDBServer
+      TaskRoleArn: !Ref RoleDBServer
       RequiresCompatibilities:
         - FARGATE
       Family: fargate-task-definition
       Cpu: '256'
       Memory: '512'
       ContainerDefinitions:
-        - Name: mongo
+        - Name: db-server
           Essential: true
           Image: 'public.ecr.aws/y7d9d7k6/mongo:5.0.6'
           PortMappings:
@@ -157,17 +176,21 @@ Resources:
             Options:
               awslogs-group: !Ref AppServerLG
               awslogs-region: !Ref 'AWS::Region'
-              awslogs-stream-prefix: ecs
+              awslogs-stream-prefix: !Ref StackName
           MountPoints:
             - ContainerPath: /data/db
               SourceVolume: mongo-efs-volume
+          Environment:
+            - Name: MONGO_INITDB_ROOT_PASSWORD
+              Value: db_password
+            - Name: MONGO_INITDB_ROOT_USERNAME
+              Value: bastion
       Volumes:
         - Name: mongo-efs-volume
           EFSVolumeConfiguration:
             FilesystemId: !Ref InstanceEFS
     DependsOn:
       - BaaSECSCluster
-      - DatabaseTaskRole
       - InstanceEFS
       - MountTarget
   BaaSNameSpace:
@@ -175,7 +198,7 @@ Resources:
     Properties:
       Description: Service Discovery Namespace for BaaS Instance
       Vpc: !Ref VPCID
-      Name: !Ref NewNameSpace
+      Name: !Ref StackName
   AppServerServiceDiscoveryEntry:
     Type: 'AWS::ServiceDiscovery::Service'
     Properties:
@@ -185,8 +208,6 @@ Resources:
           - Type: A
             TTL: '10'
         NamespaceId: !Ref BaaSNameSpace
-      HealthCheckCustomConfig:
-        FailureThreshold: '1'
     DependsOn:
       - BaaSNameSpace
   DatabaseServiceDiscoveryEntry:
@@ -198,8 +219,6 @@ Resources:
           - Type: A
             TTL: '10'
         NamespaceId: !Ref BaaSNameSpace
-      HealthCheckCustomConfig:
-        FailureThreshold: '1'
     DependsOn:
       - BaaSNameSpace
   InstanceEFS:
@@ -234,10 +253,23 @@ Resources:
         - Field: path-pattern
           PathPatternConfig:
             Values:
-              - /server/*
+              - !Ref RoutingPath
       Actions:
         - Type: forward
           ForwardConfig:
             TargetGroups:
               - TargetGroupArn: !Ref AppServerTargetGroup
                 Weight: 1
+  StackBucket:
+    Type: 'AWS::S3::Bucket'
+    Description: S3 Bucket for Cloud Code Function zip files and file storage
+    Properties:
+      BucketName: !Ref StackBucketName
+      VersioningConfiguration:
+        Status: Suspended
+      AccessControl: Private
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true

--- a/utils/config.js
+++ b/utils/config.js
@@ -11,10 +11,8 @@ const AppTierSubnet = process.env.AppTierSubnet;
 const EFSSecurityGroup = process.env.EFSSecurityGroup;
 const SGAppServer = process.env.SGAppServer;
 const SGDBServer = process.env.SGDBServer;
-const AppServerIAMRole = process.env.AppServerIAMRole;
-const DBServerIAMRole = process.env.DBServerIAMRole;
-const AppServerIAMRoleArn = process.env.AppServerIAMRoleArn;
-const DBServerIAMRoleArn = process.env.DBServerIAMRoleArn;
+const RoleAppServer = process.env.RoleAppServer;
+const RoleDBServer = process.env.RoleDBServer;
 const ALBListener = process.env.ALBListener;
 const AppServerLG = process.env.AppServerLG;
 const APP_SERVER_PARAMS = {
@@ -27,12 +25,10 @@ const APP_SERVER_PARAMS = {
   EFSSecurityGroup,
   SGAppServer,
   SGDBServer,
-  AppServerIAMRole,
-  DBServerIAMRole,
-  AppServerIAMRoleArn,
-  DBServerIAMRoleArn,
+  RoleAppServer,
+  RoleDBServer,
   ALBListener,
-  AppServerLG,
+  AppServerLG
 };
 
 const MONGO_CREDENTIALS = [

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -1,5 +1,6 @@
 const RulePriority = require('../models/listenerRulesPriority');
 const HttpError = require('../models/httpError');
+const config = require('./config');
 
 const createURL = (stackName, path) => {
   if (process.env.NODE_ENV === 'development') {
@@ -27,9 +28,11 @@ const createParams = (stackName, apiKey, TemplateBody, stackBucketName) => {
   return new Promise((resolve, reject) => {
     const TargetGroupName = stackName + 'TargetGroup';
     const ClusterName = stackName + 'Cluster';
+    const AppTaskFamily = stackName + 'TaskApp';
+    const DBTaskFamily = stackName + 'TaskDB';
     const RoutingPath = `/server/${stackName}/*`;
     const DBHost = `db.${stackName}`;
-    console.log(DBHost);
+    const stackParams = config.APP_SERVER_PARAMS
 
     newRulePriority()
       .then(rulePriority => resolve({
@@ -38,35 +41,35 @@ const createParams = (stackName, apiKey, TemplateBody, stackBucketName) => {
         Parameters: [
           {
             ParameterKey: 'VPCID',
-            ParameterValue: process.env.VpcId
+            ParameterValue: stackParams.VpcId
           },
           {
             ParameterKey: 'AppTierSubnet',
-            ParameterValue: process.env.AppTierSubnet
+            ParameterValue: stackParams.AppTierSubnet
           },
           {
             ParameterKey: 'DBTierSubnet',
-            ParameterValue: process.env.DBTierSubnet
+            ParameterValue: stackParams.DBTierSubnet
           },
           {
             ParameterKey: 'EFSSecurityGroup',
-            ParameterValue: process.env.EFSSecurityGroup
+            ParameterValue: stackParams.EFSSecurityGroup
           },
           {
             ParameterKey: 'SGAppServer',
-            ParameterValue: process.env.SGAppServer
+            ParameterValue: stackParams.SGAppServer
           },
           {
             ParameterKey: 'ALBListener',
-            ParameterValue: process.env.ALBListener
+            ParameterValue: stackParams.ALBListener
           },
           {
             ParameterKey: 'SGDBServer',
-            ParameterValue: process.env.SGDBServer
+            ParameterValue: stackParams.SGDBServer
           },
           {
             ParameterKey: 'AppServerLG',
-            ParameterValue: process.env.AppServerLG
+            ParameterValue: stackParams.AppServerLG
           },
           {
             ParameterKey: 'ListenerRulePriority',
@@ -100,6 +103,22 @@ const createParams = (stackName, apiKey, TemplateBody, stackBucketName) => {
             ParameterKey: 'DBHost',
             ParameterValue: DBHost
           },
+          {
+            ParameterKey: 'RoleAppServer',
+            ParameterValue: stackParams.RoleAppServer
+          },
+          {
+            ParameterKey: 'RoleDBServer',
+            ParameterValue: stackParams.RoleDBServer
+          },
+          {
+            ParameterKey: 'AppTaskFamily',
+            ParameterValue: AppTaskFamily
+          },
+          {
+            ParameterKey: 'DBTaskFamily',
+            ParameterValue: DBTaskFamily
+          }
         ],
         Capabilities: ['CAPABILITY_NAMED_IAM']
       }))


### PR DESCRIPTION
- Rule prio up to 1 since admin app route is default now
- enable container insights for app server cluster
- Use CLI SGs and Roles instead of re-creating them
- Set task family from StackName